### PR TITLE
feat: install Python 3.12 + pdfplumber/dateutil system-wide

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,23 @@ RUN apk --no-cache add -U weasyprint py3-brotli poppler-utils
 # Wallaby tests
 RUN apk add --update-cache g++ chromium chromium-chromedriver
 
+# CPython 3.12 (already a transitive dep of weasyprint above; here we
+# add the headers + pip so consumers can both link against libpython
+# from a NIF and install additional Python packages system-wide).
+#
+# Extra libraries installed system-wide:
+#   * py3-dateutil — common date/time helpers
+#   * py3-pillow   — image library (shared with weasyprint)
+#   * pdfplumber   — PDF text/table extraction (not in Alpine repos,
+#                    installed via pip with --break-system-packages
+#                    since the image is immutable)
+#
+# Pillow is pulled by apk before pip runs so pdfplumber reuses the
+# system Pillow that weasyprint also depends on; this avoids two
+# parallel installs racing for the same site-packages directory.
+RUN apk --no-cache add python3 python3-dev py3-pip py3-dateutil py3-pillow
+RUN pip3 install --break-system-packages --no-cache-dir "pdfplumber>=0.11.0"
+
 RUN mkdir -p /usr/share/fonts/TTF
 RUN wget -O /usr/share/fonts/TTF/Lato-Regular.ttf https://mono-colombia-public.s3.amazonaws.com/fonts/Lato-Regular.ttf
 


### PR DESCRIPTION
## Summary

Installs CPython 3.12 + the headers, `pip`, `python-dateutil`, `Pillow` and `pdfplumber` system-wide so any consumer of this base image can use Python (either as a subprocess or via a native NIF like [Pythonx](https://github.com/livebook-dev/pythonx)) without bringing its own interpreter.

No app-level naming leaks into the image: no `MONO_*` env vars, no consumer module references, no venv tied to a specific project. Consumers discover the interpreter at the standard locations (`/usr/bin/python3.12`, `/usr/lib/python3.12/site-packages`, `/usr/lib/libpython3.12.so.1.0`).

## Why system-wide instead of a project-specific venv

The previous iteration of this PR shipped a separate venv under `/opt/mono-breb-python/venv` plus an env var named after the only known consumer (mono-banking's BREB participant). Reverted in favor of a system-wide install because:

1. **Base image must stay agnostic.** Project-specific paths and env vars couple the image to a single downstream consumer.
2. **No duplicate Pillow.** `weasyprint` already pulls `py3-pillow` from apk. Installing `pdfplumber` into the same system site-packages reuses that Pillow rather than fighting with a second copy inside a venv.
3. **Simpler runtime config.** Consumers point at `/usr/bin/python3.12` directly — no `PYTHONPATH` plumbing, no marker files, no per-user venv state.

## What this image now provides

| Resource | Path | Source |
|---|---|---|
| CPython 3.12.13 | `/usr/bin/python3.12` (and `python3`, `python` symlinks) | Alpine 3.23 `python3` |
| libpython | `/usr/lib/libpython3.12.so.1.0` | Alpine 3.23 `python3-dev` |
| Site-packages | `/usr/lib/python3.12/site-packages` | system |
| `pdfplumber` 0.11.9 | system site-packages | pip (`--break-system-packages`, not packaged on Alpine) |
| `python-dateutil` 2.9.0 | system site-packages | apk `py3-dateutil` |
| `Pillow` 11.3.0 | system site-packages | apk `py3-pillow` (shared with weasyprint) |
| `weasyprint` 66.0 | system site-packages | apk (unchanged) |

## Test plan

- [x] Build locally on `linux/arm64` musl (`docker build -t phoenix-alpine:python-systemwide .`)
- [x] `python3 --version` → `3.12.13`
- [x] `weasyprint --version` → `66.0`
- [x] `python3 -c "import pdfplumber, dateutil; from PIL import Image; from weasyprint import HTML"` → no errors, all versions printed
- [x] `weasyprint` can still render HTML → PDF after the install (regression check for the existing weasyprint flow)
- [x] `python3 -c "import pdfplumber; import dateutil"` exits 0 — this is the runtime probe consumers use to detect "system Python is ready"
- [ ] Publish a new tag (e.g. `1.20.0`) and verify a downstream app boots against the new image